### PR TITLE
- fix missing "var"

### DIFF
--- a/magichome-led.js
+++ b/magichome-led.js
@@ -23,7 +23,7 @@ module.exports = function (RED) {
         //link tuya api
         const TuyaDevice = require('tuyapi');
         //and create new device
-        tuya = new TuyaDevice(tuyacfg);
+        var tuya = new TuyaDevice(tuyacfg);
         console.log("MagicHome Led Node Created");
 
         // function to try to discover the controllers IP


### PR DESCRIPTION
I'm not a javascript pro but looks like the variable tuya was jumping outside of the scope of the MagicHomeLedNode function. It did not work with multiple devices because the "tuya device" variable would get overwritten.